### PR TITLE
Validate plugin from the packer-sdc plugin-validate command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,9 +18,7 @@ builds:
     hooks:
       post:
         # This will check plugin compatibility against latest version of Packer
-        - cmd: |
-            go install github.com/hashicorp/packer/cmd/packer-plugins-check@latest &&
-            packer-plugins-check -load={{ .Name }}
+        - cmd: make plugin-check
           dir: "{{ dir .Path}}"
     flags:
       - -trimpath #removes all file system paths from the compiled executable

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,16 +10,13 @@ before:
     # As part of the release doc files are included as a separate deliverable for
     # consumption by Packer.io. To include a separate docs.zip uncomment the following command.
     - make ci-release-docs
+    # Check plugin compatibility with required version of the Packer SDK
+    - make plugin-check
 builds:
   # A separated build to run the packer-plugins-check only once for a linux_amd64 binary
   -
     id: plugin-check
     mod_timestamp: '{{ .CommitTimestamp }}'
-    hooks:
-      post:
-        # This will check plugin compatibility against latest version of Packer
-        - cmd: make plugin-check
-          dir: "{{ dir .Path}}"
     flags:
       - -trimpath #removes all file system paths from the compiled executable
     ldflags:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,6 +3,7 @@ BINARY=packer-plugin-${NAME}
 
 COUNT?=1
 TEST?=$(shell go list ./...)
+HASHICORP_PACKER_PLUGIN_SDK_VERSION?=$(shell go list -m github.com/hashicorp/packer-plugin-sdk | cut -d " " -f2)
 
 .PHONY: dev
 
@@ -16,17 +17,20 @@ dev: build
 test:
 	@go test -race -count $(COUNT) $(TEST) -timeout=3m
 
-install-gen-deps: ## Install dependencies for code generation
-	# packer-sdc allows to code generate everything needed to generate docs and
-	# HCL2 specific code.
-	@go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@latest
+install-packer-sdc: ## Install packer sofware development command
+	@go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@${HASHICORP_PACKER_PLUGIN_SDK_VERSION}
 
-ci-release-docs: install-gen-deps
+ci-release-docs: install-packer-sdc
 	@packer-sdc renderdocs -src docs -partials docs-partials/ -dst docs/
 	@/bin/sh -c "[ -d docs ] && zip -r docs.zip docs/"
+
+plugin-check: install-packer-sdc build
+	@packer-sdc plugin-check ${BINARY}
 
 testacc: dev
 	@PACKER_ACC=1 go test -count $(COUNT) -v $(TEST) -timeout=120m
 
-generate: install-gen-deps
+generate: install-packer-sdc
 	@go generate ./...
+	packer-sdc renderdocs -src ./docs -dst ./.docs -partials ./docs-partials
+	# checkout the .docs folder for a preview of the docs


### PR DESCRIPTION
Going forward, the `packer-sdc plugin-check` command will be the command to check plugins, this updates this and makes sure we are using the correct version for that.

* Use packer-sdc plugin-check from imported sdk in makefile
* make sure we have the most recent sdk
* make goreleaser use that too