### PR TITLE
Add image_pooled option

### DIFF
--- a/builder/yandex/common_config.go
+++ b/builder/yandex/common_config.go
@@ -147,6 +147,8 @@ type ImageConfig struct {
 	ImageMinDiskSizeGb int `mapstructure:"image_min_disk_size_gb" required:"false"`
 	// License IDs that indicate which licenses are attached to resulting image.
 	ImageProductIDs []string `mapstructure:"image_product_ids" required:"false"`
+	// When true, an image pool will be created for fast creation disks from the image.
+	ImagePooled bool `mapstructure:"image_pooled" required:"false"`
 	// Skip creating the image. Useful for setting to `true` during a build test stage. Defaults to `false`.
 	SkipCreateImage bool `mapstructure:"skip_create_image" required:"false"`
 }

--- a/builder/yandex/config.hcl2spec.go
+++ b/builder/yandex/config.hcl2spec.go
@@ -98,6 +98,7 @@ type FlatConfig struct {
 	ImageLabels               map[string]string `mapstructure:"image_labels" required:"false" cty:"image_labels" hcl:"image_labels"`
 	ImageMinDiskSizeGb        *int              `mapstructure:"image_min_disk_size_gb" required:"false" cty:"image_min_disk_size_gb" hcl:"image_min_disk_size_gb"`
 	ImageProductIDs           []string          `mapstructure:"image_product_ids" required:"false" cty:"image_product_ids" hcl:"image_product_ids"`
+	ImagePooled               *bool             `mapstructure:"image_pooled" required:"false" cty:"image_pooled" hcl:"image_pooled"`
 	SkipCreateImage           *bool             `mapstructure:"skip_create_image" required:"false" cty:"skip_create_image" hcl:"skip_create_image"`
 	SourceImageFamily         *string           `mapstructure:"source_image_family" required:"true" cty:"source_image_family" hcl:"source_image_family"`
 	SourceImageFolderID       *string           `mapstructure:"source_image_folder_id" required:"false" cty:"source_image_folder_id" hcl:"source_image_folder_id"`
@@ -207,6 +208,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_labels":                 &hcldec.AttrSpec{Name: "image_labels", Type: cty.Map(cty.String), Required: false},
 		"image_min_disk_size_gb":       &hcldec.AttrSpec{Name: "image_min_disk_size_gb", Type: cty.Number, Required: false},
 		"image_product_ids":            &hcldec.AttrSpec{Name: "image_product_ids", Type: cty.List(cty.String), Required: false},
+		"image_pooled":                 &hcldec.AttrSpec{Name: "image_pooled", Type: cty.Bool, Required: false},
 		"skip_create_image":            &hcldec.AttrSpec{Name: "skip_create_image", Type: cty.Bool, Required: false},
 		"source_image_family":          &hcldec.AttrSpec{Name: "source_image_family", Type: cty.String, Required: false},
 		"source_image_folder_id":       &hcldec.AttrSpec{Name: "source_image_folder_id", Type: cty.String, Required: false},

--- a/builder/yandex/step_create_image.go
+++ b/builder/yandex/step_create_image.go
@@ -40,6 +40,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 		Family:      c.ImageFamily,
 		Description: c.ImageDescription,
 		Labels:      c.ImageLabels,
+		Pooled:      c.ImagePooled,
 		MinDiskSize: toBytes(c.ImageMinDiskSizeGb),
 		ProductIds:  c.ImageProductIDs,
 		Source: &compute.CreateImageRequest_DiskId{

--- a/docs-partials/builder/yandex/ImageConfig-not-required.mdx
+++ b/docs-partials/builder/yandex/ImageConfig-not-required.mdx
@@ -15,6 +15,8 @@
 
 - `image_product_ids` ([]string) - License IDs that indicate which licenses are attached to resulting image.
 
+- `image_pooled` (boolean) - Create image optimized for deployment.
+
 - `skip_create_image` (bool) - Skip creating the image. Useful for setting to `true` during a build test stage. Defaults to `false`.
 
 <!-- End of code generated from the comments of the ImageConfig struct in builder/yandex/common_config.go; -->

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.10.1
 	github.com/hashicorp/packer-plugin-sdk v0.2.9
 	github.com/stretchr/testify v1.7.0
-	github.com/yandex-cloud/go-genproto v0.0.0-20210419102011-ea71516bb3f7
+	github.com/yandex-cloud/go-genproto v0.0.0-20211115083454-9ca41db5ed9e
 	github.com/yandex-cloud/go-sdk v0.0.0-20210413100926-1c3eb10c58d7
 	github.com/zclconf/go-cty v1.9.1
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5

--- a/go.sum
+++ b/go.sum
@@ -560,6 +560,8 @@ github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgq
 github.com/yandex-cloud/go-genproto v0.0.0-20210413095726-6b0dcd341e19/go.mod h1:HEUYX/p8966tMUHHT+TsS0hF/Ca/NYwqprC5WXSDMfE=
 github.com/yandex-cloud/go-genproto v0.0.0-20210419102011-ea71516bb3f7 h1:qI0iykKTUTAFQ34/7cpnFZefKJTa5vprwPs8ncTkFGQ=
 github.com/yandex-cloud/go-genproto v0.0.0-20210419102011-ea71516bb3f7/go.mod h1:HEUYX/p8966tMUHHT+TsS0hF/Ca/NYwqprC5WXSDMfE=
+github.com/yandex-cloud/go-genproto v0.0.0-20211115083454-9ca41db5ed9e h1:9LPdmD1vqadsDQUva6t2O9MbnyvoOgo8nFNPaOIH5U8=
+github.com/yandex-cloud/go-genproto v0.0.0-20211115083454-9ca41db5ed9e/go.mod h1:HEUYX/p8966tMUHHT+TsS0hF/Ca/NYwqprC5WXSDMfE=
 github.com/yandex-cloud/go-sdk v0.0.0-20210413100926-1c3eb10c58d7 h1:uPMQzYjpkRcn7oWGvFpMKOwgwO4gUm3v7dITULSYw6s=
 github.com/yandex-cloud/go-sdk v0.0.0-20210413100926-1c3eb10c58d7/go.mod h1:cxZ4BdZRJC1XMqb7x09H26zzy6NB9uL9SfcwqIvYmyw=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/post-processor/yandex-import/post-processor.hcl2spec.go
+++ b/post-processor/yandex-import/post-processor.hcl2spec.go
@@ -30,6 +30,7 @@ type FlatConfig struct {
 	ImageLabels           map[string]string `mapstructure:"image_labels" required:"false" cty:"image_labels" hcl:"image_labels"`
 	ImageMinDiskSizeGb    *int              `mapstructure:"image_min_disk_size_gb" required:"false" cty:"image_min_disk_size_gb" hcl:"image_min_disk_size_gb"`
 	ImageProductIDs       []string          `mapstructure:"image_product_ids" required:"false" cty:"image_product_ids" hcl:"image_product_ids"`
+	ImagePooled           *bool             `mapstructure:"image_pooled" required:"false" cty:"image_pooled" hcl:"image_pooled"`
 	SkipCreateImage       *bool             `mapstructure:"skip_create_image" required:"false" cty:"skip_create_image" hcl:"skip_create_image"`
 	Bucket                *string           `mapstructure:"bucket" required:"false" cty:"bucket" hcl:"bucket"`
 	ObjectName            *string           `mapstructure:"object_name" required:"false" cty:"object_name" hcl:"object_name"`
@@ -66,6 +67,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_description":          &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
 		"image_family":               &hcldec.AttrSpec{Name: "image_family", Type: cty.String, Required: false},
 		"image_labels":               &hcldec.AttrSpec{Name: "image_labels", Type: cty.Map(cty.String), Required: false},
+		"image_pooled":               &hcldec.AttrSpec{Name: "image_pooled", Type: cty.Bool, Required: false},
 		"image_min_disk_size_gb":     &hcldec.AttrSpec{Name: "image_min_disk_size_gb", Type: cty.Number, Required: false},
 		"image_product_ids":          &hcldec.AttrSpec{Name: "image_product_ids", Type: cty.List(cty.String), Required: false},
 		"skip_create_image":          &hcldec.AttrSpec{Name: "skip_create_image", Type: cty.Bool, Required: false},

--- a/post-processor/yandex-import/utils.go
+++ b/post-processor/yandex-import/utils.go
@@ -72,6 +72,7 @@ func createYCImage(ctx context.Context, driver yandex.Driver, ui packersdk.Ui, i
 		Name:        c.ImageConfig.ImageName,
 		Description: c.ImageConfig.ImageDescription,
 		Labels:      c.ImageConfig.ImageLabels,
+		Pooled:      c.ImageConfig.ImagePooled,
 		Family:      c.ImageConfig.ImageFamily,
 		MinDiskSize: int64(c.ImageMinDiskSizeGb),
 		ProductIds:  c.ImageProductIDs,


### PR DESCRIPTION
The `--pooled` option created image, optimized for fast deployment.
The feature is in preview now, but is very useful for deployment of
large number of instances.

The option is supported in Yandex CLI client and web application.

Implemented as 'image_pooled` option. Not sure about proper naming,
but there is already image_min_disk_size. Implementation needs
update of Yandex SDK dependency.

