### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/docs-partials/post-processor/yandex-export/Config-required.mdx
+++ b/docs-partials/post-processor/yandex-export/Config-required.mdx
@@ -2,8 +2,8 @@
 
 - `paths` ([]string) - List of paths to Yandex Object Storage where exported image will be uploaded.
   Please be aware that use of space char inside path not supported.
-  Also this param support [build](/docs/templates/legacy_json_templates/engine) template function.
-  Check available template data for [Yandex](/docs/builders/yandex#build-template-data) builder.
+  Also this param support [build](/packer/docs/templates/legacy_json_templates/engine) template function.
+  Check available template data for [Yandex](/packer/plugins/builders/yandex#build-template-data) builder.
   Paths to Yandex Object Storage where exported image will be uploaded.
 
 <!-- End of code generated from the comments of the Config struct in post-processor/yandex-export/post-processor.go; -->

--- a/docs-partials/post-processor/yandex-import/Config-not-required.mdx
+++ b/docs-partials/post-processor/yandex-import/Config-not-required.mdx
@@ -7,7 +7,7 @@
   in storage service and first paths (URL) is used to, so no need to set this param.
 
 - `object_name` (string) - The name of the object key in `bucket` where the qcow2 file will be copied to import.
-  This is a [template engine](/docs/templates/legacy_json_templates/engine).
+  This is a [template engine](/packer/docs/templates/legacy_json_templates/engine).
   Therefore, you may use user variables and template functions in this field.
 
 - `skip_clean` (bool) - Whether skip removing the qcow2 file uploaded to Storage

--- a/docs/builders/yandex.mdx
+++ b/docs/builders/yandex.mdx
@@ -90,7 +90,7 @@ Configuration options are organized below into two categories: required and
 optional. Within each category, the available options are alphabetized and
 described.
 
-In addition to the options listed here, a [communicator](/docs/templates/legacy_json_templates/communicator)
+In addition to the options listed here, a [communicator](/packer/docs/templates/legacy_json_templates/communicator)
 can be configured for this builder. In addition to the options defined there, a private key file
 can also be supplied to override the typical auto-generated key:
 
@@ -160,7 +160,7 @@ In configuration directives the following variables are available:
 ## Build Shared Information Variables
 
 This builder generates data that are shared with provisioner and post-processor via build function of
-[template engine](/docs/templates/legacy_json_templates/engine) for JSON and [contextual variables](/docs/templates/hcl_templates/contextual-variables)
+[template engine](/packer/docs/templates/legacy_json_templates/engine) for JSON and [contextual variables](/packer/docs/templates/hcl_templates/contextual-variables)
 for HCL2.
 
 The generated variables available for this builder see above

--- a/docs/post-processors/yandex-export.mdx
+++ b/docs/post-processors/yandex-export.mdx
@@ -28,7 +28,7 @@ As such, assigned Service Account must have write permissions to the Yandex Obje
 `paths`. A new temporary static access keys from assigned Service Account used to upload
 image.
 
-Also, you should configure [ssh communicator](/docs/communicators/ssh). Default `ssh_username` to `ubuntu`.
+Also, you should configure [ssh communicator](/packer/docs/communicators/ssh). Default `ssh_username` to `ubuntu`.
 
 ## Configuration
 

--- a/post-processor/yandex-export/post-processor.go
+++ b/post-processor/yandex-export/post-processor.go
@@ -45,8 +45,8 @@ type Config struct {
 
 	// List of paths to Yandex Object Storage where exported image will be uploaded.
 	// Please be aware that use of space char inside path not supported.
-	// Also this param support [build](/docs/templates/legacy_json_templates/engine) template function.
-	// Check available template data for [Yandex](/docs/builders/yandex#build-template-data) builder.
+	// Also this param support [build](/packer/docs/templates/legacy_json_templates/engine) template function.
+	// Check available template data for [Yandex](/packer/plugins/builders/yandex#build-template-data) builder.
 	// Paths to Yandex Object Storage where exported image will be uploaded.
 	Paths []string `mapstructure:"paths" required:"true"`
 

--- a/post-processor/yandex-import/post-processor.go
+++ b/post-processor/yandex-import/post-processor.go
@@ -31,7 +31,7 @@ type Config struct {
 	// in storage service and first paths (URL) is used to, so no need to set this param.
 	Bucket string `mapstructure:"bucket" required:"false"`
 	// The name of the object key in `bucket` where the qcow2 file will be copied to import.
-	// This is a [template engine](/docs/templates/legacy_json_templates/engine).
+	// This is a [template engine](/packer/docs/templates/legacy_json_templates/engine).
 	// Therefore, you may use user variables and template functions in this field.
 	ObjectName string `mapstructure:"object_name" required:"false"`
 	// Whether skip removing the qcow2 file uploaded to Storage

--- a/website/content/docs/builders/yandex.mdx
+++ b/website/content/docs/builders/yandex.mdx
@@ -64,7 +64,7 @@ Configuration options are organized below into two categories: required and
 optional. Within each category, the available options are alphabetized and
 described.
 
-In addition to the options listed here, a [communicator](/docs/templates/legacy_json_templates/communicator)
+In addition to the options listed here, a [communicator](/packer/docs/templates/legacy_json_templates/communicator)
 can be configured for this builder. In addition to the options defined there, a private key file
 can also be supplied to override the typical auto-generated key:
 
@@ -136,7 +136,7 @@ In configuration directives the following variables are available:
 ## Build Shared Information Variables
 
 This builder generates data that are shared with provisioner and post-processor via build function of
-[template engine](/docs/templates/legacy_json_templates/engine) for JSON and [contextual variables](/docs/templates/hcl_templates/contextual-variables)
+[template engine](/packer/docs/templates/legacy_json_templates/engine) for JSON and [contextual variables](/packer/docs/templates/hcl_templates/contextual-variables)
 for HCL2.
 
 The generated variables available for this builder see above


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them