### PR TITLE
bump go 1.18 to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/packer-plugin-yandex
 
-go 1.18
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.44.114


### PR DESCRIPTION
- github: remove test-plugin-example workflow
- go.mod: bump go version from 1.18 to 1.19
