### PR TITLE
Allow direct Qemu-built image artifact upload

### DIFF
--- a/post-processor/yandex-import/post-processor.go
+++ b/post-processor/yandex-import/post-processor.go
@@ -133,8 +133,8 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 	// TODO: this is to avoid a dep loop: uncomment when Packer core stops
 	// importing this plugin.
 	// case compress.BuilderId, artifice.BuilderId, file.BuilderId:
-	case "packer.post-processor.compress", "packer.post-processor.artifice", "packer.file":
-		// Artifact as a file, need to be uploaded to storage before create Compute Image
+	case "packer.post-processor.compress", "packer.post-processor.artifice", "packer.file", "transcend.qemu":
+		// Artifact as a file, needs to be uploaded to storage before Compute Image could be created
 		fileSource = true
 
 		// As `bucket` option validate input here
@@ -168,7 +168,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 
 	default:
 		err := fmt.Errorf(
-			"Unknown artifact type: %s\nCan only import from Yandex-Export, Yandex-Import, Compress, Artifice and File post-processor artifacts.",
+			"Unknown artifact type: %s\nCan only import from Yandex-Export, Yandex-Import, Compress, Artifice, File and Qemu post-processor artifacts.",
 			artifact.BuilderId())
 		return nil, false, false, err
 	}


### PR DESCRIPTION
**Description**
PR allows allows direct upload of [Qemu-generated images](https://developer.hashicorp.com/packer/plugins/builders/qemu) into Yandex Cloud.
Qemu builder typically produces a single `.qcow2` image file, which could later be uploaded and processed.

**Use Case(s)**
This saves the need to have a glue between Qemu-built artifacts and the import post-processor.

