### PR TITLE
Use Object Storage URL Presigning for image create

### DIFF
--- a/post-processor/yandex-import/post-processor.go
+++ b/post-processor/yandex-import/post-processor.go
@@ -139,10 +139,14 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 
 		// As `bucket` option validate input here
 		if p.config.Bucket == "" {
-			return nil, false, false, fmt.Errorf("To upload artfact you need to specify `bucket` value")
+			return nil, false, false, fmt.Errorf("To upload artifact you need to specify `bucket` value")
 		}
 
-		imageSrc, err = uploadToBucket(storageClient, ui, artifact, p.config.Bucket, p.config.ObjectName)
+		uploadedImage, err := uploadToBucket(storageClient, ui, artifact, p.config.Bucket, p.config.ObjectName)
+		if err != nil {
+			return nil, false, false, err
+		}
+		imageSrc, err = presignUrl(storageClient, ui, uploadedImage.GetSourceID())
 		if err != nil {
 			return nil, false, false, err
 		}

--- a/post-processor/yandex-import/storage_test.go
+++ b/post-processor/yandex-import/storage_test.go
@@ -48,7 +48,7 @@ func Test_s3URLToBucketKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotBucket, gotKey, err := s3URLToBucketKey(tt.storageURL)
+			gotBucket, gotKey, err := s3URLToBucketKey(tt.storageURL, "https://"+defaultStorageEndpoint)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("s3URLToBucketKey() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/post-processor/yandex-import/utils.go
+++ b/post-processor/yandex-import/utils.go
@@ -138,7 +138,7 @@ func deleteFromBucket(s3conn *s3.S3, ui packersdk.Ui, imageSrc cloudImageSource)
 		return fmt.Errorf("invalid argument for `deleteFromBucket` method: %v", v)
 	}
 
-	bucket, objectName, err := s3URLToBucketKey(url)
+	bucket, objectName, err := s3URLToBucketKey(url, s3conn.Endpoint)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR extends `presignUrl()` function usage to include file-based sources to be uploaded on Object Storage.

Closes #86

