### PR TITLE
Fix ipv6 address format

### DIFF
--- a/builder/yandex/step_instance_info.go
+++ b/builder/yandex/step_instance_info.go
@@ -57,7 +57,7 @@ func getInstanceIPAddress(c *Config, instance *compute.Instance) (address string
 
 	if c.UseIPv6 {
 		if addrIPV6Addr != "" {
-			return "[" + addrIPV6Addr + "]", nil
+			return addrIPV6Addr, nil
 		}
 		return "", errors.New("instance has no one IPv6 address")
 	}


### PR DESCRIPTION
Remove extra brackets for IPv6 address because the latest version of packer-plugin-sdk already handles them - https://github.com/hashicorp/packer-plugin-sdk/pull/246


